### PR TITLE
fix: non-existent attribute for templatefile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ locals {
       workingDirectory       = var.workingDirectory == "" ? "null" : var.workingDirectory
   })
 
-  container_definition  = var.register_task_definition ? format("[%s]", templatefiles.rendered) : format("%s", templatefiles.rendered)
+  container_definition  = var.register_task_definition ? format("[%s]", templatefiles) : format("%s", templatefiles)
   container_definitions = replace(local.container_definition, "/\"(null)\"/", "$1")
 }
 


### PR DESCRIPTION
This PR fix a regression in https://github.com/docebo-labs/terraform-aws-ecs-task-definition/pull/4.